### PR TITLE
Update google-analytics docs url

### DIFF
--- a/packages/google-analytics/README.md
+++ b/packages/google-analytics/README.md
@@ -1,1 +1,1 @@
-This module's documentation can be found at https://developers.google.com/web/tools/workbox/modules/workbox-google-analytics
+This module's documentation can be found at https://developer.chrome.com/docs/workbox/modules/workbox-google-analytics


### PR DESCRIPTION
The old link redirects to the workbox homepage