### PR TITLE
fix(next): check if the current page is in the service worker's scope

### DIFF
--- a/.changeset/sour-rings-lay.md
+++ b/.changeset/sour-rings-lay.md
@@ -1,0 +1,9 @@
+---
+"@serwist/next": patch
+---
+
+fix(next): check if the current page is in the service worker's scope before registering
+
+- Before, if `InjectPartial.scope` was set to some value, and you visited a page out of that scope, you would see the warning "The current page is not in scope for the registered service worker. Was this a mistake?" logged. This simply fixes that by checking if the page is in the scope before calling `window.serwist.register()`.
+
+- Wondering if we should have removed /sw-entry.ts before the 9.0.0 release...

--- a/packages/next/src/sw-entry.ts
+++ b/packages/next/src/sw-entry.ts
@@ -1,4 +1,5 @@
 import { Serwist } from "@serwist/window";
+import { isCurrentPageOutOfScope } from "@serwist/window/internal";
 
 import type { SerwistNextOptions } from "./internal-types.js";
 import type { MessageType } from "./sw-entry-worker.js";
@@ -16,17 +17,17 @@ declare const self: Window &
   };
 
 if (typeof window !== "undefined" && "serviceWorker" in navigator && typeof caches !== "undefined") {
+  const scope = self.__SERWIST_SW_ENTRY.scope;
+
   let swEntryWorker: Worker | undefined;
 
   if (self.__SERWIST_SW_ENTRY.swEntryWorker) {
     swEntryWorker = new Worker(self.__SERWIST_SW_ENTRY.swEntryWorker);
   }
 
-  window.serwist = new Serwist(window.location.origin + self.__SERWIST_SW_ENTRY.sw, {
-    scope: self.__SERWIST_SW_ENTRY.scope,
-  });
+  window.serwist = new Serwist(window.location.origin + self.__SERWIST_SW_ENTRY.sw, { scope });
 
-  if (self.__SERWIST_SW_ENTRY.register) {
+  if (self.__SERWIST_SW_ENTRY.register && !isCurrentPageOutOfScope(scope)) {
     window.serwist.register();
   }
 

--- a/packages/window/package.json
+++ b/packages/window/package.json
@@ -3,19 +3,8 @@
   "version": "9.0.0",
   "type": "module",
   "description": "Simplifies communications with Serwist packages running in the service worker",
-  "files": [
-    "src",
-    "dist"
-  ],
-  "keywords": [
-    "serwist",
-    "serwistjs",
-    "service worker",
-    "sw",
-    "window",
-    "message",
-    "postMessage"
-  ],
+  "files": ["src", "dist"],
+  "keywords": ["serwist", "serwistjs", "service worker", "sw", "window", "message", "postMessage"],
   "author": "Google's Web DevRel Team, Serwist's Team",
   "license": "MIT",
   "repository": "https://github.com/serwist/serwist",
@@ -23,10 +12,19 @@
   "homepage": "https://serwist.pages.dev",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "internal": ["./dist/index.internal.d.ts"]
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/index.internal.d.ts",
+      "default": "./dist/index.internal.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/window/rollup.config.js
+++ b/packages/window/rollup.config.js
@@ -9,6 +9,7 @@ export default getRollupOptions({
     {
       input: {
         index: "src/index.ts",
+        "index.internal": "src/index.internal.ts",
       },
       output: {
         dir: "dist",

--- a/packages/window/src/Serwist.ts
+++ b/packages/window/src/Serwist.ts
@@ -13,6 +13,7 @@ import { messageSW } from "./messageSW.js";
 import type { SerwistLifecycleEventMap } from "./utils/SerwistEvent.js";
 import { SerwistEvent } from "./utils/SerwistEvent.js";
 import { SerwistEventTarget } from "./utils/SerwistEventTarget.js";
+import { isCurrentPageOutOfScope } from "./utils/isCurrentPageOutOfScope.js";
 import { urlsMatch } from "./utils/urlsMatch.js";
 
 // The time a SW must be in the waiting phase before we can conclude
@@ -172,12 +173,7 @@ export class Serwist extends SerwistEventTarget {
         }
       }
 
-      const currentPageIsOutOfScope = () => {
-        const scopeURL = new URL(this._registerOptions.scope || this._scriptURL.toString(), document.baseURI);
-        const scopeURLBasePath = new URL("./", scopeURL.href).pathname;
-        return !location.pathname.startsWith(scopeURLBasePath);
-      };
-      if (currentPageIsOutOfScope()) {
+      if (isCurrentPageOutOfScope(this._registerOptions.scope || this._scriptURL.toString())) {
         logger.warn("The current page is not in scope for the registered service worker. Was this a mistake?");
       }
     }

--- a/packages/window/src/index.internal.ts
+++ b/packages/window/src/index.internal.ts
@@ -1,0 +1,3 @@
+import { isCurrentPageOutOfScope } from "./utils/isCurrentPageOutOfScope.js";
+
+export { isCurrentPageOutOfScope };

--- a/packages/window/src/utils/isCurrentPageOutOfScope.ts
+++ b/packages/window/src/utils/isCurrentPageOutOfScope.ts
@@ -1,0 +1,5 @@
+export const isCurrentPageOutOfScope = (scope: string) => {
+  const scopeURL = new URL(scope, document.baseURI);
+  const scopeURLBasePath = new URL("./", scopeURL.href).pathname;
+  return !location.pathname.startsWith(scopeURLBasePath);
+};


### PR DESCRIPTION
Fixes #99.

Before, if `InjectPartial.scope` was set to some value, and you visited a page out of that scope, you would see the warning "The current page is not in scope for the registered service worker. Was this a mistake?" logged. This simply fixes that by checking if the page is in the scope before calling `window.serwist.register()`.

Wondering if we should have removed /sw-entry.ts before the 9.0.0 release...