### PR TITLE
fix(vite): add missing types for typings subpackage export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ output/
 # vscode
 .vscode
 
+# jetbrains ide
+.idea
+
 # rollup
 .rollup.cache
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -5,7 +5,8 @@
   "description": "A module that integrates Serwist into your Vite application.",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "*.d.ts"
   ],
   "keywords": [
     "react",


### PR DESCRIPTION
`typings.d.ts` not included in the final tgz.

This PR also includes `.idea` folder (JetBrains IDE) in the `.gitignore` file.

Without this PR (https://arethetypeswrong.github.io/?p=%40serwist%2Fvite%409.0.1):

![imagen](https://github.com/serwist/serwist/assets/6311119/4f2bfd20-f8c8-4f30-95a9-1fef1db0d225)

With this PR:

![imagen](https://github.com/serwist/serwist/assets/6311119/72a41ed9-5518-43ef-a091-6a74d9f29987)
