### PR TITLE
Strategy handler logging fix

### DIFF
--- a/contributing/core/developing.md
+++ b/contributing/core/developing.md
@@ -9,7 +9,7 @@ To develop locally:
 
 1. Clone the Serwist repository:
    ```
-   git clone https://github.com/serwist/serwist -- --depth=3000 --branch main --single-branch
+   git clone https://github.com/serwist/serwist --depth=3000 --branch main --single-branch
    ```
 1. Create a new branch:
    ```

--- a/contributing/docs/adding-docs.md
+++ b/contributing/docs/adding-docs.md
@@ -7,7 +7,7 @@
 
 1. Clone the Serwist repository:
    ```
-   git clone https://github.com/serwist/serwist -- --depth=3000 --branch main --single-branch
+   git clone https://github.com/serwist/serwist --depth=3000 --branch main --single-branch
    ```
 1. Create a new branch:
    ```

--- a/packages/core/src/lib/strategies/StrategyHandler.ts
+++ b/packages/core/src/lib/strategies/StrategyHandler.ts
@@ -526,20 +526,16 @@ export class StrategyHandler {
 
     if (!pluginsUsed) {
       if (responseToCache && responseToCache.status !== 200) {
-        responseToCache = undefined;
-      }
-      if (process.env.NODE_ENV !== "production") {
-        if (responseToCache) {
-          if (responseToCache.status !== 200) {
-            if (responseToCache.status === 0) {
-              logger.warn(
-                `The response for '${this.request.url}' is an opaque response. The caching strategy that you're using will not cache opaque responses by default.`,
-              );
-            } else {
-              logger.debug(`The response for '${this.request.url}' returned a status code of '${response.status}' and won't be cached as a result.`);
-            }
+        if (process.env.NODE_ENV !== "production") {
+          if (responseToCache.status === 0) {
+            logger.warn(
+              `The response for '${this.request.url}' is an opaque response. The caching strategy that you're using will not cache opaque responses by default.`,
+            );
+          } else {
+            logger.debug(`The response for '${this.request.url}' returned a status code of '${response.status}' and won't be cached as a result.`);
           }
         }
+        responseToCache = undefined;
       }
     }
 


### PR DESCRIPTION
Dev logging in `StrategyHandler` `_ensureResponseSafeToCache` would previously never get called as `responseToCache` was set to `undefined` before checking the status to log. Have rearranged the logic to fix this.

Also as I was following the docs to make this change I noticed the git clone command had some extra `--` so updated the docs to fix this.

Super minor things but thought I'd make a PR just in case it's useful!