### PR TITLE
fix(webpack-plugin): compatibility with Rspack

### DIFF
--- a/packages/webpack-plugin/src/inject-manifest.ts
+++ b/packages/webpack-plugin/src/inject-manifest.ts
@@ -177,8 +177,12 @@ export class InjectManifest {
         if (error) {
           reject(error);
         } else {
-          compilation.warnings = compilation.warnings.concat(childCompilation?.warnings ?? []);
-          compilation.errors = compilation.errors.concat(childCompilation?.errors ?? []);
+          if (childCompilation?.warnings) {
+            compilation.warnings.push(...childCompilation.warnings);
+          }
+          if (childCompilation?.errors) {
+            compilation.errors.push(...childCompilation.errors);
+          }
 
           resolve();
         }


### PR DESCRIPTION
Currently, `@serwist/webpack-plugin` fails to run in `Rspack` and `Rsbuild` by throwing `TypeError: Cannot set property warnings of #<Compilation> which has only a getter`.

The reason for this error is that `Compilation` instance in Rspack has read-only properties for `warnings` and `errors` arrays unlike webpack and the plugin tries to assign a concatenated array.

The issue can be remedied by using `push` instead of `concat` on the `warnings` and `errors` arrays.