### PR TITLE
fix(deps): reverted `glob` to v10 and `rimraf` to v5

### DIFF
--- a/.changeset/fast-rockets-beam.md
+++ b/.changeset/fast-rockets-beam.md
@@ -6,8 +6,8 @@
 "@serwist/cli": patch
 ---
 
-fix(dependencies): reverted `glob` to v10
+fix(dependencies): reverted `glob` to v10 and `rimraf` to v5
 
-- Turns out `glob` v11 drops support for Node.js 18, so we are back to v10 for now.
+- Turns out `glob` v11 and `rimraf` v6 drops support for Node.js 18, so we are back to v10 for now.
 
 - This also adds test for Node.js 18 and 22.

--- a/.changeset/fast-rockets-beam.md
+++ b/.changeset/fast-rockets-beam.md
@@ -1,0 +1,13 @@
+---
+"@serwist/webpack-plugin": patch
+"@serwist/build": patch
+"@serwist/next": patch
+"@serwist/vite": patch
+"@serwist/cli": patch
+---
+
+fix(dependencies): reverted `glob` to v10
+
+- Turns out `glob` v11 drops support for Node.js 18, so we are back to v10 for now.
+
+- This also adds test for Node.js 18 and 22.

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ${{ fromJson(inputs.nodeVersion || '["20.x"]') }}
+        node-version: ${{ fromJson(inputs.nodeVersion || '["18.x", "20.x", "22.x"]') }}
         os: [ubuntu-latest]
     steps:
       - name: Checkout repo

--- a/__tests__/next/package.json
+++ b/__tests__/next/package.json
@@ -10,7 +10,7 @@
     "@serwist/next": "workspace:*",
     "cheerio": "1.0.0-rc.12",
     "fs-extra": "11.2.0",
-    "glob": "11.0.0",
+    "glob": "10.4.5",
     "next": "14.2.5",
     "serwist": "workspace:*",
     "vitest": "2.0.3"

--- a/ncu.js
+++ b/ncu.js
@@ -17,7 +17,7 @@ const packageJsonList = await fg("**/package.json", {
 const examplesPackageJsonList = await fg("examples/*/package.json", {
   ignore: ["**/node_modules/**"],
 });
-const excludePackages = ["eslint", "@biomejs/biome", "glob"];
+const excludePackages = ["eslint", "@biomejs/biome", "glob", "rimraf"];
 
 /**
  * @type {Promise<any>[]}

--- a/ncu.js
+++ b/ncu.js
@@ -17,7 +17,7 @@ const packageJsonList = await fg("**/package.json", {
 const examplesPackageJsonList = await fg("examples/*/package.json", {
   ignore: ["**/node_modules/**"],
 });
-const excludePackages = ["eslint", "@biomejs/biome"];
+const excludePackages = ["eslint", "@biomejs/biome", "glob"];
 
 /**
  * @type {Promise<any>[]}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "npm-check-updates": "16.14.20",
     "prettier-plugin-svelte": "3.2.5",
     "prettier-plugin-tailwindcss": "0.6.5",
-    "rimraf": "6.0.1",
+    "rimraf": "5.0.9",
     "shell-quote": "1.8.1",
     "ts-node": "10.9.2",
     "tslib": "2.6.3",

--- a/packages/$legacy/background-sync/rollup.config.js
+++ b/packages/$legacy/background-sync/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/broadcast-update/rollup.config.js
+++ b/packages/$legacy/broadcast-update/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/cacheable-response/rollup.config.js
+++ b/packages/$legacy/cacheable-response/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/core-legacy/rollup.config.js
+++ b/packages/$legacy/core-legacy/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/expiration/rollup.config.js
+++ b/packages/$legacy/expiration/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/google-analytics/rollup.config.js
+++ b/packages/$legacy/google-analytics/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/navigation-preload/rollup.config.js
+++ b/packages/$legacy/navigation-preload/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/precaching/rollup.config.js
+++ b/packages/$legacy/precaching/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/range-requests/rollup.config.js
+++ b/packages/$legacy/range-requests/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/routing/rollup.config.js
+++ b/packages/$legacy/routing/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/strategies/rollup.config.js
+++ b/packages/$legacy/strategies/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/$legacy/sw/rollup.config.js
+++ b/packages/$legacy/sw/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -54,7 +54,7 @@
     "common-tags": "1.8.2",
     "fast-json-stable-stringify": "2.1.0",
     "fs-extra": "11.2.0",
-    "glob": "11.0.0",
+    "glob": "10.4.5",
     "pretty-bytes": "6.1.1",
     "rollup": "4.18.1",
     "source-map": "0.8.0-beta.0",

--- a/packages/build/rollup.config.js
+++ b/packages/build/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "chokidar": "3.6.0",
     "common-tags": "1.8.2",
     "fs-extra": "11.2.0",
-    "glob": "11.0.0",
+    "glob": "10.4.5",
     "meow": "13.2.0",
     "pretty-bytes": "6.1.1",
     "stringify-object": "5.0.0",

--- a/packages/cli/rollup.config.js
+++ b/packages/cli/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,7 +72,7 @@
     "@serwist/webpack-plugin": "workspace:*",
     "@serwist/window": "workspace:*",
     "chalk": "5.3.0",
-    "glob": "11.0.0",
+    "glob": "10.4.5",
     "serwist": "workspace:*",
     "zod": "3.23.8"
   },

--- a/packages/next/rollup.config.js
+++ b/packages/next/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -79,7 +79,7 @@
     "@types/node": "20.14.10",
     "eslint": "8.57.0",
     "nuxt": "3.12.3",
-    "rimraf": "6.0.1",
+    "rimraf": "5.0.9",
     "serve": "14.2.3",
     "typescript": "5.5.3",
     "vite": "5.3.4",

--- a/packages/recipes/rollup.config.js
+++ b/packages/recipes/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/streams/rollup.config.js
+++ b/packages/streams/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/svelte/rollup.config.js
+++ b/packages/svelte/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@serwist/build": "workspace:*",
     "serwist": "workspace:*",
-    "glob": "11.0.0",
+    "glob": "10.4.5",
     "kolorist": "1.8.0",
     "zod": "3.23.8"
   },

--- a/packages/vite/src/rollup.js
+++ b/packages/vite/src/rollup.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "../package.json" assert { type: "json" };
+import packageJson from "../package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -11,6 +11,8 @@
     "serwist",
     "serwistjs",
     "webpack",
+    "rspack",
+    "rsbuild",
     "service worker",
     "caching",
     "fetch requests",

--- a/packages/webpack-plugin/rollup.config.js
+++ b/packages/webpack-plugin/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/packages/webpack-plugin/src/inject-manifest.ts
+++ b/packages/webpack-plugin/src/inject-manifest.ts
@@ -183,7 +183,6 @@ export class InjectManifest {
           if (childCompilation?.errors) {
             compilation.errors.push(...childCompilation.errors);
           }
-
           resolve();
         }
       });

--- a/packages/window/rollup.config.js
+++ b/packages/window/rollup.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { getRollupOptions } from "@serwist/configs/rollup";
 
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 export default getRollupOptions({
   packageJson,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       glob:
-        specifier: 11.0.0
-        version: 11.0.0
+        specifier: 10.4.5
+        version: 10.4.5
       next:
         specifier: 14.2.5
         version: 14.2.5(@babel/core@7.24.7)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -682,8 +682,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       glob:
-        specifier: 11.0.0
-        version: 11.0.0
+        specifier: 10.4.5
+        version: 10.4.5
       pretty-bytes:
         specifier: 6.1.1
         version: 6.1.1
@@ -746,8 +746,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       glob:
-        specifier: 11.0.0
-        version: 11.0.0
+        specifier: 10.4.5
+        version: 10.4.5
       meow:
         specifier: 13.2.0
         version: 13.2.0
@@ -823,8 +823,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       glob:
-        specifier: 11.0.0
-        version: 11.0.0
+        specifier: 10.4.5
+        version: 10.4.5
       serwist:
         specifier: workspace:*
         version: link:../core
@@ -978,8 +978,8 @@ importers:
         specifier: workspace:*
         version: link:../build
       glob:
-        specifier: 11.0.0
-        version: 11.0.0
+        specifier: 10.4.5
+        version: 10.4.5
       kolorist:
         specifier: 1.8.0
         version: 1.8.0
@@ -5101,9 +5101,8 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  glob@10.4.2:
-    resolution: {integrity: sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==}
-    engines: {node: '>=16 || 14 >=14.18'}
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
   glob@11.0.0:
@@ -11806,7 +11805,7 @@ snapshots:
 
   archiver-utils@5.0.2:
     dependencies:
-      glob: 10.4.2
+      glob: 10.4.5
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
@@ -12012,7 +12011,7 @@ snapshots:
     dependencies:
       '@npmcli/fs': 3.1.0
       fs-minipass: 3.0.3
-      glob: 10.4.2
+      glob: 10.4.5
       lru-cache: 7.18.3
       minipass: 7.1.2
       minipass-collect: 1.0.2
@@ -13193,7 +13192,7 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
-  glob@10.4.2:
+  glob@10.4.5:
     dependencies:
       foreground-child: 3.1.1
       jackspeak: 3.1.2
@@ -15620,7 +15619,7 @@ snapshots:
 
   read-package-json@6.0.4:
     dependencies:
-      glob: 10.4.2
+      glob: 10.4.5
       json-parse-even-better-errors: 3.0.0
       normalize-package-data: 5.0.0
       npm-normalize-package-bin: 3.0.1
@@ -15737,7 +15736,7 @@ snapshots:
 
   rimraf@5.0.7:
     dependencies:
-      glob: 10.4.2
+      glob: 10.4.5
 
   rimraf@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: 0.6.5
         version: 0.6.5(prettier-plugin-svelte@3.2.5(prettier@3.2.5)(svelte@5.0.0-next.186))(prettier@3.2.5)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 5.0.9
+        version: 5.0.9
       shell-quote:
         specifier: 1.8.1
         version: 1.8.1
@@ -906,8 +906,8 @@ importers:
         specifier: 3.12.3
         version: 3.12.3(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@20.14.10)(encoding@0.1.13)(eslint@8.57.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@3.29.4)(terser@5.27.0)(typescript@5.5.3)(vite@5.3.4(@types/node@20.14.10)(terser@5.27.0))(vue-tsc@2.0.26(typescript@5.5.3))
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 5.0.9
+        version: 5.0.9
       serve:
         specifier: 14.2.3
         version: 14.2.3
@@ -5105,11 +5105,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
-  glob@11.0.0:
-    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
-    engines: {node: 20 || >=22}
-    hasBin: true
-
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -5540,10 +5535,6 @@ packages:
     resolution: {integrity: sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==}
     engines: {node: '>=14'}
 
-  jackspeak@4.0.1:
-    resolution: {integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==}
-    engines: {node: 20 || >=22}
-
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
@@ -5763,10 +5754,6 @@ packages:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
 
-  lru-cache@11.0.0:
-    resolution: {integrity: sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==}
-    engines: {node: 20 || >=22}
-
   lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
@@ -5981,10 +5968,6 @@ packages:
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -6455,10 +6438,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
 
   path-to-regexp@2.2.1:
     resolution: {integrity: sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==}
@@ -7218,14 +7197,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@5.0.7:
-    resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
-    engines: {node: '>=14.18'}
-    hasBin: true
-
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
-    engines: {node: 20 || >=22}
+  rimraf@5.0.9:
+    resolution: {integrity: sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==}
+    engines: {node: 14 >=14.20 || 16 >=16.20 || >=18}
     hasBin: true
 
   rollup-plugin-dts@6.1.0:
@@ -13201,15 +13175,6 @@ snapshots:
       package-json-from-dist: 1.0.0
       path-scurry: 1.11.1
 
-  glob@11.0.0:
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 4.0.1
-      minimatch: 10.0.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.0
-      path-scurry: 2.0.0
-
   glob@7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -13678,12 +13643,6 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jackspeak@4.0.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 20.14.10
@@ -13887,8 +13846,6 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.2.0: {}
-
-  lru-cache@11.0.0: {}
 
   lru-cache@4.1.5:
     dependencies:
@@ -14248,10 +14205,6 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -14581,7 +14534,7 @@ snapshots:
       prompts-ncu: 3.0.0
       rc-config-loader: 4.1.3
       remote-git-tags: 3.0.0
-      rimraf: 5.0.7
+      rimraf: 5.0.9
       semver: 7.6.0
       semver-utils: 1.1.4
       source-map-support: 0.5.21
@@ -15068,11 +15021,6 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.2.0
-      minipass: 7.1.2
-
-  path-scurry@2.0.0:
-    dependencies:
-      lru-cache: 11.0.0
       minipass: 7.1.2
 
   path-to-regexp@2.2.1: {}
@@ -15734,14 +15682,9 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@5.0.7:
+  rimraf@5.0.9:
     dependencies:
       glob: 10.4.5
-
-  rimraf@6.0.1:
-    dependencies:
-      glob: 11.0.0
-      package-json-from-dist: 1.0.0
 
   rollup-plugin-dts@6.1.0(rollup@3.29.4)(typescript@5.5.3):
     dependencies:


### PR DESCRIPTION
Turns out `glob` v11 and `rimraf` v6 drops support for Node.js 18, so we are back to v10 and v5 for now.

This also adds test for Node.js 18 and 22.
