### PR TITLE
fix(webpack-plugin): explicitly call `WebWorkerTemplatePlugin`

### DIFF
--- a/.changeset/cuddly-grapes-pretend.md
+++ b/.changeset/cuddly-grapes-pretend.md
@@ -1,0 +1,7 @@
+---
+"@serwist/webpack-plugin": patch
+---
+
+fix(webpack-plugin): explicitly call webpack's internal `WebWorkerTemplatePlugin`
+
+- This plugin calls `ArrayPushCallbackChunkFormatPlugin` on our child compiler, allowing chunks to work properly.

--- a/packages/webpack-plugin/src/lib/types.ts
+++ b/packages/webpack-plugin/src/lib/types.ts
@@ -7,6 +7,7 @@ import type {
   OptionalSwDestResolved,
 } from "@serwist/build";
 import type { Require } from "@serwist/utils";
+import type { WebpackPluginFunction, WebpackPluginInstance } from "webpack";
 
 export interface WebpackPartial {
   /**
@@ -57,7 +58,7 @@ export interface InjectPartial {
    * Optional webpack plugins that will be used when compiling the `swSrc`
    * file. Only valid if `compileSrc` is `true`.
    */
-  webpackCompilationPlugins?: any[];
+  webpackCompilationPlugins?: (WebpackPluginFunction | WebpackPluginInstance)[];
 }
 
 export type InjectResolved = Require<InjectPartial, "compileSrc">;


### PR DESCRIPTION
Fixes #188.

This plugin calls `ArrayPushCallbackChunkFormatPlugin` on our child compiler, allowing chunks to work properly.
