### PR TITLE
fix(next): __dirname to inner scope

### DIFF
--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -11,13 +11,14 @@ import { getContentHash, getFileHash, loadTSConfig, logger } from "./lib/index.j
 import type { InjectManifestOptions, InjectManifestOptionsComplete } from "./lib/types.js";
 import { validateInjectManifestOptions } from "./lib/validator.js";
 
+const dirname = "__dirname" in globalThis ? __dirname : fileURLToPath(new URL(".", import.meta.url));
+
 /**
  * Integrates Serwist into your Next.js app.
  * @param userOptions
  * @returns
  */
 const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: NextConfig) => NextConfig) => {
-  const __dirname = fileURLToPath(new URL(".", import.meta.url));
   
   return (nextConfig = {}) => ({
     ...nextConfig,
@@ -66,7 +67,7 @@ const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: Nex
         } satisfies Record<`${SerwistNextOptionsKey}.${Exclude<keyof SerwistNextOptions, "swEntryWorker">}`, string | undefined>),
       );
 
-      const swEntryJs = path.join(__dirname, "sw-entry.js");
+      const swEntryJs = path.join(dirname, "sw-entry.js");
       const entry = config.entry as () => Promise<Record<string, string[] | string>>;
       config.entry = async () => {
         const entries = await entry();
@@ -142,7 +143,7 @@ const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: Nex
         let swEntryWorkerDest: string | undefined = undefined;
 
         if (shouldBuildSWEntryWorker) {
-          const swEntryWorkerSrc = path.join(__dirname, "sw-entry-worker.js");
+          const swEntryWorkerSrc = path.join(dirname, "sw-entry-worker.js");
           const swEntryName = `swe-worker-${getContentHash(swEntryWorkerSrc, dev)}.js`;
           swEntryPublicPath = path.posix.join(basePath, swEntryName);
           swEntryWorkerDest = path.join(destDir, swEntryName);

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -11,14 +11,14 @@ import { getContentHash, getFileHash, loadTSConfig, logger } from "./lib/index.j
 import type { InjectManifestOptions, InjectManifestOptionsComplete } from "./lib/types.js";
 import { validateInjectManifestOptions } from "./lib/validator.js";
 
-const __dirname = fileURLToPath(new URL(".", import.meta.url));
-
 /**
  * Integrates Serwist into your Next.js app.
  * @param userOptions
  * @returns
  */
 const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: NextConfig) => NextConfig) => {
+  const __dirname = fileURLToPath(new URL(".", import.meta.url));
+  
   return (nextConfig = {}) => ({
     ...nextConfig,
     webpack(config: Configuration, options) {


### PR DESCRIPTION
If you use `storybook` and `serwist` together, they will conflict for `__dirname` variable. 
Because it is already created with a global scope, it cannot be used by branching from the business logic it uses.
So I suggest moving to scope within the function.

<img width="800" alt="스크린샷 2024-11-05 오후 4 38 28" src="https://github.com/user-attachments/assets/24acfae1-0f5d-4cd3-9c83-b0243a3c8cc1">
