### PR TITLE
[doc] Adds `manifestEntries` argument type

### DIFF
--- a/docs/src/routes/(vertical)/docs/build/configuring/manifest-transforms/+page.svx
+++ b/docs/src/routes/(vertical)/docs/build/configuring/manifest-transforms/+page.svx
@@ -22,7 +22,7 @@ One or more functions which will be applied sequentially against the generated m
   <Tab id="build-ts">
 
 ```typescript
-const manifestTransform: ManifestTransform = async (manifestEntries) => {
+const manifestTransform: ManifestTransform = async (manifestEntries: ManifestEntry[]) => {
   const manifest = manifestEntries.map((m) => {
     if (m.url === "dQw4w9WgXcQ") m.url = "get-rick-rolled.mp4";
     if (m.revision === null) m.revision = crypto.randomUUID();


### PR DESCRIPTION
Here is a missing type for the `manifestEntries` argument, at page https://serwist.pages.dev/docs/build/configuring/manifest-transforms.