### PR TITLE
[doc] Update example for `InjectManifestOptions` as current example is not valid

### DIFF
--- a/docs/src/routes/(vertical)/docs/build/configuring/injection-point/+page.svx
+++ b/docs/src/routes/(vertical)/docs/build/configuring/injection-point/+page.svx
@@ -26,7 +26,7 @@ await injectManifest({
   swSrc: "app/sw.ts",
   swDest: "dist/sw.js",
   globDirectory: "dist/static",
-  injectionPoint: "__HI_MOM",
+  injectionPoint: "self.__HI_MOM",
 });
 ```
 


### PR DESCRIPTION
without the `self.` included before the custom injection point the replacement will not work correctly and cause JS errors in production

https://developer.chrome.com/docs/workbox/modules/workbox-build#type-InjectManifestOptions