### PR TITLE
fix(next): re-word turbopack console warning to fix issue URL

### DIFF
--- a/.changeset/petite-eels-allow.md
+++ b/.changeset/petite-eels-allow.md
@@ -1,0 +1,5 @@
+---
+"@serwist/next": patch
+---
+
+re-word turbopack console warning to fix issue URL

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -24,7 +24,7 @@ const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: Nex
   if (!warnedTurbopack && process.env.TURBOPACK && !userOptions.disable && !process.env.SERWIST_SUPPRESS_TURBOPACK_WARNING) {
     warnedTurbopack = true;
     console.warn(
-      `[@serwist/next] WARNING: You are using '@serwist/next' with \`next dev --turbopack\`, but Serwist doesn't support Turbopack at the moment. It is recommended that you set \`disable\` to \`process.env.NODE_ENV !== \"production\"\`. Follow this issue for progress on Serwist + Turbopack: https://github.com/serwist/serwist/issues/54. You can also suppress this warning by setting SERWIST_SUPPRESS_TURBOPACK_WARNING=1.`,
+      `[@serwist/next] WARNING: You are using '@serwist/next' with \`next dev --turbopack\`, but Serwist doesn't support Turbopack at the moment. It is recommended that you set \`disable\` to \`process.env.NODE_ENV !== \"production\"\`. Follow this issue for progress on Serwist + Turbopack: https://github.com/serwist/serwist/issues/54 . You can also suppress this warning by setting SERWIST_SUPPRESS_TURBOPACK_WARNING=1.`,
     );
   }
   return (nextConfig = {}) => ({

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -24,7 +24,7 @@ const withSerwistInit = (userOptions: InjectManifestOptions): ((nextConfig?: Nex
   if (!warnedTurbopack && process.env.TURBOPACK && !userOptions.disable && !process.env.SERWIST_SUPPRESS_TURBOPACK_WARNING) {
     warnedTurbopack = true;
     console.warn(
-      `[@serwist/next] WARNING: You are using '@serwist/next' with \`next dev --turbopack\`, but Serwist doesn't support Turbopack at the moment. It is recommended that you set \`disable\` to \`process.env.NODE_ENV !== \"production\"\`. Follow this issue for progress on Serwist + Turbopack: https://github.com/serwist/serwist/issues/54 . You can also suppress this warning by setting SERWIST_SUPPRESS_TURBOPACK_WARNING=1.`,
+      `[@serwist/next] WARNING: You are using '@serwist/next' with \`next dev --turbopack\`, but Serwist doesn't support Turbopack at the moment. It is recommended that you set \`disable\` to \`process.env.NODE_ENV !== \"production\"\`. Follow https://github.com/serwist/serwist/issues/54 for progress on Serwist + Turbopack. You can also suppress this warning by setting SERWIST_SUPPRESS_TURBOPACK_WARNING=1.`,
     );
   }
   return (nextConfig = {}) => ({


### PR DESCRIPTION
Small QOL fix to turbopack console warning.

If the user is using a terminal application that supports hyperlinks (I'm using Hyper), the period is causing the linked issue (#54) to break. Adding a space between the URL and the period should fix it.

Re-wording the warning to move the URL away from the end of the sentence is also an option.

https://github.com/user-attachments/assets/f9d9cb64-b81e-483b-b159-fd9836cfde32

