### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/packages/nuxt/src/config.ts
+++ b/packages/nuxt/src/config.ts
@@ -20,7 +20,7 @@ export function configurePwaOptions(options: ModuleOptions, nuxt: Nuxt, nitroCon
   // handle payload extraction
   if (nuxt.options.experimental.payloadExtraction) {
     const enableGlobPatterns =
-      nuxt.options._generate || !!nitroConfig.prerender?.routes?.length || Object.values(nitroConfig.routeRules ?? {}).some((r: any) => r.prerender);
+      nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */ || !!nitroConfig.prerender?.routes?.length || Object.values(nitroConfig.routeRules ?? {}).some((r: any) => r.prerender);
     if (enableGlobPatterns) {
       options.globPatterns = options.globPatterns ?? [];
       options.globPatterns.push("**/_payload.json");


### PR DESCRIPTION

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.