### PR TITLE
fix: ignore _global-error.html

### DIFF
--- a/.changeset/odd-doors-argue.md
+++ b/.changeset/odd-doors-argue.md
@@ -1,0 +1,5 @@
+---
+"@serwist/next": patch
+---
+
+fix(next/cli): ignore \_global-error.html

--- a/packages/next/src/index.config.ts
+++ b/packages/next/src/index.config.ts
@@ -66,7 +66,7 @@ export const serwist: Serwist = async (options, nextConfig, { cwd = _cwd, isDev 
     ],
     globIgnores: [
       `${distAppDir}**/_not-found.html`,
-      `${distAppDir}**/_global-error.html`,
+      `${distAppDir}_global-error*`,
       `${distPagesDir}404.html`,
       `${distPagesDir}500.html`,
       ...(cliOptions.globIgnores ?? []),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### General

- A changeset has been added via `pnpm changeset`.

### Adding or Updating Examples

- [The examples guidelines](https://github.com/serwist/serwist/blob/main/contributing/examples/adding-examples.md) are properly followed.

### Fixing a bug

- Related issues/discussions are linked using `fixes #number`.

- (if needed) Tests are added to ensure the error does not happen again.

### Adding a feature

- The PR should implement an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.

- Related issues/discussions are linked using `fixes #number`

- Documentation should be added to https://github.com/serwist/docs via a separate PR after merging.

## What?

## Why?

## How?

Fixes # -->

ignore `_global-error.html`.

<img width="1379" height="705" alt="image" src="https://github.com/user-attachments/assets/8d496bfb-a909-4a0e-a962-a2aac3b04c9e" />

minimal reproduction

https://github.com/Debbl/serwist-global-error-html

```bash
pnpm i

pnpm build

pnpm start
```

