### PR TITLE
fix(window): don't throw when register() resolves without a registration

### DIFF
--- a/.changeset/plenty-donkeys-tickle.md
+++ b/.changeset/plenty-donkeys-tickle.md
@@ -1,0 +1,7 @@
+---
+"@serwist/window": patch
+---
+
+fix(window): don't throw when `navigator.serviceWorker.register()` resolves without a registration
+
+`Serwist.register()` read `.waiting` off the result of `navigator.serviceWorker.register()` without checking it first. That call is specified to resolve with a registration or reject, but not every environment honours it — under Playwright's `serviceWorkers: "block"` it resolves with `undefined`, and the read threw `TypeError: Cannot read properties of undefined (reading 'waiting')`. Since the common call sites fire registration without a rejection handler, that surfaced as an unhandled rejection at boot. `register()` now returns `undefined` in that case, which its return type already allowed.

--- a/packages/window/src/Serwist.ts
+++ b/packages/window/src/Serwist.ts
@@ -117,6 +117,19 @@ export class Serwist extends SerwistEventTarget {
 
     this._registration = await this._registerScript();
 
+    // `navigator.serviceWorker.register()` is specified to either resolve with
+    // a registration or reject, but not every environment honours that. Under
+    // Playwright's `serviceWorkers: "block"`, for instance, it resolves with
+    // `undefined`. Bail out instead of dereferencing that below: a
+    // registration that yielded nothing should degrade to "no service worker",
+    // which `undefined` — already part of this method's return type — says.
+    if (!this._registration) {
+      if (process.env.NODE_ENV !== "production") {
+        logger.warn("The browser resolved the service worker registration with nothing. Service workers are likely blocked or unavailable here.");
+      }
+      return;
+    }
+
     // If we have a compatible controller, store the controller as the "own"
     // SW, resolve active/controlling deferreds and add necessary listeners.
     if (this._compatibleControllingSW) {


### PR DESCRIPTION
Fixes #363.

### The bug

`Serwist.register()` awaits `_registerScript()` and then dereferences the result without checking it ([`Serwist.ts#L118-L135`](https://github.com/serwist/serwist/blob/main/packages/window/src/Serwist.ts#L118-L135)):

```ts
this._registration = await this._registerScript();
// ...
const waitingSW = this._registration.waiting;
```

`navigator.serviceWorker.register()` is specified to resolve with a registration or reject, but not every environment honours that. Under Playwright's [`serviceWorkers: "block"`](https://playwright.dev/docs/api/class-testoptions#test-options-service-workers) it resolves with literal `undefined`, so the read throws:

```
TypeError: Cannot read properties of undefined (reading 'waiting')
```

Because the usual call sites fire registration without a rejection handler — `<SerwistProvider register>` does `void window.serwist.register()` from inside a `useState` initializer ([`index.react.tsx#L44`](https://github.com/serwist/serwist/blob/main/packages/turbopack/src/index.react.tsx#L44)) — a consumer has nothing to attach a `.catch()` to, so it lands as an unhandled rejection at boot. In Next.js dev that reads as `⨯ unhandledRejection` and can take the wrapped route's client tree down with it.

### The change

Return early when the platform hands back nothing. `register()` is already typed `Promise<ServiceWorkerRegistration | undefined>`, so this is in-contract and not a breaking change — a registration that yielded nothing now degrades to "no service worker" instead of throwing. `messageSkipWaiting()` already guards the same property with `this._registration?.waiting` ([L277](https://github.com/serwist/serwist/blob/main/packages/window/src/Serwist.ts#L277)); `register()` was the outlier.

Dev-only `logger.warn` so the degraded path isn't silent while debugging.

### Verification

Same page, same blocked context, two builds of `@serwist/window` — the published 9.5.11 from esm.sh, then a local build of this branch:

| build | `navigator.serviceWorker.register()` resolved | `Serwist.register()` |
| --- | --- | --- |
| `9.5.11` | `undefined` | throws `TypeError: … (reading 'waiting')` |
| this branch | `undefined` | resolves `undefined`, no unhandled rejection |

Patched run, verbatim:

```
{
  "unhandled": null,
  "caught": null,
  "resolved": "undefined",
  "rawRegisterResolvedTo": "undefined"
}
```

with the new warning in the console:

```
serwist The browser resolved the service worker registration with nothing.
Service workers are likely blocked or unavailable here.
```

Reproduction — a static page plus one Playwright test, no bundler and no framework — is inlined in full in [this comment on #363](https://github.com/serwist/serwist/issues/363#issuecomment-5112200409), so it doesn't depend on a repo I'm hosting.

`pnpm turbo build --filter=@serwist/window...`, `pnpm run typecheck`, and `pnpm run lint` all pass in `packages/window`.

I didn't add a unit test — `__tests__/` has no window/DOM harness today and standing one up felt like more than this fix should carry. Happy to add one if you'd like it, in whatever shape suits you.

### Note

There's an argument that `<SerwistProvider>` should own its registration promise regardless, so a rejection from *any* cause can't escape unhandled. That's a separate change and I left it out of this PR — glad to open it if it's of interest.

